### PR TITLE
fix: 使用SBI 2.0 DBCN扩展完成调试输出功能

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ spin = { version = "0.9", default-features = false, features = [
 ] }
 smallvec = "1.13"
 chrono = { version = "0.4", default-features = false }
-sbi-rt = { version = "0.0.3", features = ["legacy"] }
+sbi-rt = "0.0.3"
 event-listener = { version = "5.3", default-features = false }
 heapless = { version = "0.8", features = ["mpmc_large"] }
 scopeguard = { version = "1.2", default-features = false }

--- a/crates/kernel/src/uart_console.rs
+++ b/crates/kernel/src/uart_console.rs
@@ -27,8 +27,7 @@ pub fn eprint(args: Arguments<'_>) {
     impl Write for Stderr {
         fn write_str(&mut self, s: &str) -> Result {
             for byte in s.bytes() {
-                #[allow(deprecated)]
-                sbi_rt::legacy::console_putchar(byte as usize);
+                sbi_rt::console_write_byte(byte);
             }
             Ok(())
         }


### PR DESCRIPTION
SBI 2.0版本的DBCN扩展代替了被启用的legacy console扩展。出于legacy SBI（0.1版本）已经在2021年被弃用，最新的固件通常提供2.0版本的新扩展，因此我们使用新扩展完成控制台输出功能。

完成此项改变后，项目中去除了一个`#[allow(deprecated)]`提示，且无需启用`sbi-rt`弃用的legacy扩展，使得代码更健壮。

r? @idlercloud 